### PR TITLE
svtrace.py: add python shebang

### DIFF
--- a/svtracing/svtrace.py
+++ b/svtracing/svtrace.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (C) 2024, RTE (http://www.rte-france.com)
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This allows to run svtrace.py in a shell.